### PR TITLE
Handle splash screen navigation logic

### DIFF
--- a/real_estate_app/lib/screens/splash_screen.dart
+++ b/real_estate_app/lib/screens/splash_screen.dart
@@ -19,16 +19,17 @@ class _SplashScreenState extends State<SplashScreen> {
 	@override
 	void initState() {
 		super.initState();
-		_timer = Timer(const Duration(milliseconds: 1200), _goNext);
+		WidgetsBinding.instance.addPostFrameCallback((_) {
+			_timer = Timer(const Duration(milliseconds: 1200), _goNext);
+		});
 	}
 
 	void _goNext() {
+		if (!mounted) return;
 		final userProvider = context.read<UserProvider>();
-		if (userProvider.isAuthenticated) {
-			Navigator.of(context).pushReplacementNamed(AppRoutes.home);
-		} else {
-			Navigator.of(context).pushReplacementNamed(AppRoutes.onboarding);
-		}
+		final String targetRoute = userProvider.isAuthenticated ? AppRoutes.home : AppRoutes.onboarding;
+		if (!mounted) return;
+		Navigator.of(context).pushNamedAndRemoveUntil(targetRoute, (_) => false);
 	}
 
 	@override


### PR DESCRIPTION
Refactor splash screen navigation to ensure proper transition and prevent it from getting stuck.

The previous implementation could lead to the splash screen getting stuck due to navigation attempts occurring before the widget was fully rendered or after it was unmounted. This change ensures navigation is scheduled after the first frame, guards against using an unmounted context, and clears the navigation stack to prevent loops.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a7a9b4a-4ce8-4747-b9e8-4306d16e2e8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a7a9b4a-4ce8-4747-b9e8-4306d16e2e8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

